### PR TITLE
Attempt to use 1.16.[3-4] version for 1.16.[1-2]

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -20,6 +20,6 @@ displayURL="https://www.curseforge.com/minecraft/mc-mods/brazier"
 [[dependencies.brazier]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.3, 1.17)"
+    versionRange="[1.16.1, 1.17)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
### Changed
- Version range to allow usage with 1.16.1 & 1.16.2 (experimental)