### PR TITLE
Made living_torch deploying recipe to only load if Create is installed

### DIFF
--- a/common/src/main/resources/data/brazier/recipes/deploying/living_torch.json
+++ b/common/src/main/resources/data/brazier/recipes/deploying/living_torch.json
@@ -1,4 +1,12 @@
 {
+  "fabric:load_conditions":[
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
   "type": "create:deploying",
   "ingredients": [
     {


### PR DESCRIPTION
### - Added `fabric:load_conditions` to the living torch recipe for Create's deploying, making the recipe to only load when the Create mod is installed to your game. 